### PR TITLE
Sanity check configuration and add JAILDATASET option

### DIFF
--- a/src/bin/mkjail
+++ b/src/bin/mkjail
@@ -51,6 +51,45 @@ HELP
 exit 0
 }
 
+_load_config() {
+    local config_file="$1" ; shift
+
+   if [ -r "$config_file" ]; then
+       . "$config_file"
+    else
+        echo "Unable to load configuration from $config_file." >&2
+        exit $EX_CONFIG
+    fi
+
+    # set defaults
+    : "${ZPOOL:=""}"
+    : "${JAILDATASET:="jails"}"
+    : "${JAILROOT:="/jails"}"
+    : "${SETS:="base"}"
+
+    if [ "$ZPOOL" = "" ]; then
+        echo "ZPOOL is required and must not be empty, " \
+            "check your configuration in $config_file." >&2
+        exit $EX_CONFIG
+    fi
+
+    if [ "$JAILDATASET" = "" ]; then
+        echo "JAILDATASET is required and must not be empty, " \
+            "check your configuration in $config_file." >&2
+        exit $EX_CONFIG
+    fi
+
+    if [ "$JAILROOT" = "" ]; then
+        echo "JAILROOT is required and must not be empty, " \
+            "check your configuration in $config_file." >&2
+        exit $EX_CONFIG
+    fi
+
+    check_zfs_dataset_config "$ZPOOL/$JAILDATASET" "$JAILROOT" "$config_file"
+
+    export ZPOOL JAILDATASET JAILROOT SETS
+}
+
 [ $# -lt 1 ] && show_help
 
 CMD=$1
@@ -59,9 +98,6 @@ MKJAILPATH=`realpath $0`
 if [ "${MKJAILPATH%src/bin/mkjail}" != "${MKJAILPATH}" ]; then
         # It is running from src/bin/mkjail in checkout
         MKJAILPREFIX=${MKJAILPATH%/bin/*}
-        set -a
-        . ${MKJAILPREFIX}/etc/mkjail.conf
-        set +a
 elif [ "${MKJAILPATH%/bin/*}" = "${MKJAILPATH}" ]; then
         # It is running in a build directory or the source checkout as
         # ./mkjail.  Lookup VPATH to resolve to source checkout if in
@@ -69,18 +105,17 @@ elif [ "${MKJAILPATH%/bin/*}" = "${MKJAILPATH}" ]; then
         [ -f Makefile ] && VPATH="$(make -V VPATH)"
         MKJAILPREFIX="${MKJAILPATH%/mkjail}${VPATH:+/${VPATH}}/src"
         [ -n "${VPATH}" ] && MKJAILPREFIX="$(realpath "${MKJAILPREFIX}")"
-        set -a
-        . ${MKJAILPREFIX}/etc/mkjail.conf
-        set +a
 else
         # Running from PREFIX/bin/mkjail
         MKJAILPREFIX=${MKJAILPATH%/bin/*}
-        set -a
-        . ${MKJAILPREFIX}/etc/mkjail.conf
-        set +a
 fi
 
 export SCRIPTPREFIX=${MKJAILPREFIX}/share/mkjail
+
+. "$SCRIPTPREFIX/lib.sh"
+
+_load_config "${MKJAILPREFIX}/etc/mkjail.conf"
+
 SCRIPTPATH="${SCRIPTPREFIX}/${CMD}.sh"
 
 case "${CMD}" in

--- a/src/etc/mkjail.conf.sample
+++ b/src/etc/mkjail.conf.sample
@@ -3,9 +3,15 @@
 # Set your zpool name
 ZPOOL="zroot"
 
+# Set the jail dataset name (without the zpool name)
+# DEFAULT: jails
+JAILDATASET="jails"
+
 # Set jail root filesystem path
+# DEFAULT: /jails
 JAILROOT="/jails"
 
 # Sets you want extracted into new jail
 # options include: base-dbg, base, kernel-dbg, kernel, lib32-dbg, lib32, ports, src tests
+# DEFAULT: base
 SETS="base lib32"

--- a/src/share/mkjail/lib.sh
+++ b/src/share/mkjail/lib.sh
@@ -1,0 +1,51 @@
+# /usr/include/sysexits.h
+EX_OK=0         # successful termination
+EX_ERROR=1      # unsuccessful termination
+EX_USAGE=64     # command line usage error
+EX_CANTCREAT=73 # can't create (user) output file
+EX_CONFIG=78    # configuration error
+
+
+create_zfs_dataset() {
+    # Create a ZFS dataset if it does not exist
+    local dataset_name=$1
+    local mount_point=$2
+
+    if ! zfs list -H -o name "$dataset_name" >/dev/null; then
+        echo "Creating dataset $dataset_name"
+        zfs create -p -o mountpoint="$mount_point" "$dataset_name"
+        local ret=$?
+        if [ "$ret" -ne 0 ]; then
+            echo "Unable to create dataset $dataset_name" >&2
+            exit $EX_CANTCREAT
+        fi
+    fi
+}
+
+check_zfs_dataset_config() {
+    # Check a ZFS dataset exists and it' mount point is correct
+    local dataset_name=$1
+    local cfg_mount_point=$2
+    local config_file=$3
+
+    local ds_mount_point=$(
+        zfs get -H -o value mountpoint "$dataset_name" 2>/dev/null || \
+            echo "NOT_EXIST"
+    )
+    case "$ds_mount_point" in
+        "NOT_EXIST"|"$cfg_mount_point")
+            # OK, if it doesn't exist it will be created later
+            ;;
+
+        "none")
+            echo "ZFS dataset $dataset_name has no mount point set" >&2
+            exit $EX_CONFIG
+            ;;
+
+        *)
+            echo "Mount point for ZFS dataset $dataset_name does not match " \
+                "$cfg_mount_point, check your configuration in $config_file." >&2
+            exit $EX_CONFIG
+            ;;
+    esac
+}

--- a/src/share/mkjail/update.sh
+++ b/src/share/mkjail/update.sh
@@ -7,12 +7,12 @@ PAGER=cat
 _set_version()
 {
     local NEWJAILVER=$(${JAILROOT}/${JAILNAME}/bin/freebsd-version -u)
-    zfs set mkjail:version=${NEWJAILVER} ${ZPOOL}${JAILROOT}/${JAILNAME}
+    zfs set mkjail:version="${NEWJAILVER}" "${ZPOOL}/${JAILDATASET}/${JAILNAME}"
 }
 
 _get_version()
 {
-    zfs get -Hp mkjail:version ${JAILROOT}/${JAILNAME} | awk '{print $3}' | sed -E 's,-p[0-9]+,,'
+    zfs get -Hp mkjail:version "${ZPOOL}/${JAILDATASET}/${JAILNAME}" | awk '{print $3}' | sed -E 's,-p[0-9]+,,'
 }
 
 _alljails()


### PR DESCRIPTION
* Ensure the required settings are configured in `mkjail.conf` and that
  they make sense before we run wild with the `zfs` command.

* Added a `JAILDATASET` option for setups where the jail dataset name
  doesn't match the mount point name, for example:

```
NAME                MOUNTPOINT
zroot/jails         /usr/local/jails
```

The above example would require the following mkjail.conf:

```bash
ZPOOL="zroot"
JAILDATASET="jails"
JAILROOT="/usr/local/jails"
```

* Fix #18 and remove the hardcoded references to the jail dataset.

* Created `lib.sh` to hold reusable functions.