### PR TITLE
add MKJAILDATASET, similar to JAILDATASET

### DIFF
--- a/src/bin/mkjail
+++ b/src/bin/mkjail
@@ -64,6 +64,7 @@ _load_config() {
     # set defaults
     : "${ZPOOL:=""}"
     : "${JAILDATASET:="jails"}"
+    : "${MKJAILDATASET:="mkjail"}"
     : "${JAILROOT:="/jails"}"
     : "${SETS:="base"}"
 
@@ -87,7 +88,7 @@ _load_config() {
 
     check_zfs_dataset_config "$ZPOOL/$JAILDATASET" "$JAILROOT" "$config_file"
 
-    export ZPOOL JAILDATASET JAILROOT SETS
+    export ZPOOL JAILDATASET MKJAILDATASET JAILROOT SETS
 }
 
 [ $# -lt 1 ] && show_help

--- a/src/etc/mkjail.conf.sample
+++ b/src/etc/mkjail.conf.sample
@@ -9,6 +9,10 @@ ZPOOL="zroot"
 # DEFAULT: jails
 JAILDATASET="jails"
 
+# mkjail will create $ZPOOL/$MKJAILDATASET/${VERSION}
+# by default, this is mkjail
+MKJAILDATASET="mkjail"
+
 # Set jail root filesystem path.
 # This is where the jails are mounted.
 # DEFAULT: /jails

--- a/src/share/mkjail/getrelease.sh
+++ b/src/share/mkjail/getrelease.sh
@@ -57,13 +57,13 @@ _getrelease()
 
     _manifest || _cleanup
 
-    zfs create -p ${ZPOOL}/mkjail/${VERSION}
+    zfs create -p ${ZPOOL}/${MKJAILDATASET}/${VERSION}
 
-    if [ "$(zfs get -H mountpoint ${ZPOOL}/mkjail | awk '{print $3}')" = "none" ]; then
-        zfs set mountpoint=/mkjail ${ZPOOL}/mkjail
+    if [ "$(zfs get -H mountpoint ${ZPOOL}/${MKJAILDATASET} | awk '{print $3}')" = "none" ]; then
+        zfs set mountpoint=/mkjail ${ZPOOL}/${MKJAILDATASET}
     fi
 
-    SRCPATH="$(zfs get -H mountpoint ${ZPOOL}/mkjail | awk '{print $3}')/${VERSION}"
+    SRCPATH="$(zfs get -H mountpoint ${ZPOOL}/${MKJAILDATASET} | awk '{print $3}')/${VERSION}"
 
     echo "Extracting src for use in jail upgrades..."
     tar -xzpf /var/db/mkjail/releases/${ARCH}/${VERSION}/src.txz -C ${SRCPATH}/

--- a/src/share/mkjail/upgrade.sh
+++ b/src/share/mkjail/upgrade.sh
@@ -164,12 +164,12 @@ if [ ${aflag} -eq 1 ] && [ ${jflag} -eq 1 ]; then
 fi
 
 if [ ${aflag} -eq 1 ]; then
-    SRCPATH="$(zfs get -H mountpoint ${ZPOOL}/mkjail | awk '{print $3}')/${TARGETVER}"
+    SRCPATH="$(zfs get -H mountpoint ${ZPOOL}/${MKJAILDATASET} | awk '{print $3}')/${TARGETVER}"
     _alljails
 fi
 
 if [ ${jflag} -eq 1 ]; then
-    SRCPATH="$(zfs get -H mountpoint ${ZPOOL}/mkjail | awk '{print $3}')/${TARGETVER}"
+    SRCPATH="$(zfs get -H mountpoint ${ZPOOL}/${MKJAILDATASET} | awk '{print $3}')/${TARGETVER}"
     _upgradejail
 fi
 


### PR DESCRIPTION
instead of always creating `${ZPOOL}/mkjail`, let's use `$ZPOOL/$MKJAILDATASET`

Existing behaviour is retained by defaulting to `mkjail`.

This new feature is useful when creating jails within jails.