### PR TITLE
getrelease needs lib32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/etc/mkjail.conf

--- a/src/share/mkjail/getrelease.sh
+++ b/src/share/mkjail/getrelease.sh
@@ -40,8 +40,8 @@ _manifest()
 
 _getrelease()
 {
-    # Ensure we always have src in the sets
-    SETS=$(echo "${SETS}" src | awk -v RS="[ \n]+" '!n[$0]++')
+    # Ensure we always have src and lib32 in the sets
+    SETS=$(echo "${SETS}" src lib32 | awk -v RS="[ \n]+" '!n[$0]++')
 
     mkdir -p /var/db/mkjail/releases/${ARCH}/${VERSION}
 


### PR DESCRIPTION
We check for lib32 before attempting an upgrade and error out requesting
a getrelease run if the lib32.txz isn't there and the jail needs it. If
we don't always have lib32.txz available you're stuck until you update the mkjail.conf
to add lib32 to SETS