### PR TITLE
Removes dependancy on `lib32` for upgrading jails.

### DIFF
--- a/src/share/mkjail/upgrade.sh
+++ b/src/share/mkjail/upgrade.sh
@@ -82,7 +82,6 @@ _validate()
 
     # Check if we have the sets for the target version we are upgrading to
     [ -f /var/db/mkjail/releases/${ARCH}/${TARGETVER}/base.txz ] || _getrelease
-    [ -f /var/db/mkjail/releases/${ARCH}/${TARGETVER}/lib32.txz ] || _getrelease
     [ -f /var/db/mkjail/releases/${ARCH}/${TARGETVER}/src.txz ] || _getrelease
     [ -d ${SRCPATH} ] || _getrelease
 }


### PR DESCRIPTION
The default config file list only `base` in the sets (with `src` always downloaded by default. However, the `upgrade` command will fail, telling the user to run `getrelease` for the upgrade version, if the `lib32` is not downloaded as well.

This patch removes the dependency on `lib32`.