### PR TITLE
exit show_help() properly

### DIFF
--- a/src/share/mkjail/getrelease.sh
+++ b/src/share/mkjail/getrelease.sh
@@ -79,6 +79,7 @@ usage: mkjail getrelease [-s "SETS"] [-v VERSION]
 mkjail.sh: 2019, feld@FreeBSD.org
 
 HELP
+exit 0
 }
 
 exit_opts_req() {


### PR DESCRIPTION
Hi,
The command `mkjail getrelease -h` outputs the help 2 times in a row.
That's because of a missing `exit 0` at the end of the function called `show_help()`.

Thank you.
