### PR TITLE
hide route message

### DIFF
--- a/src/share/mkjail/create.sh
+++ b/src/share/mkjail/create.sh
@@ -5,8 +5,8 @@ set -e
 
 : ${ARCH=$(uname -m)}
 
-ip4int=$(route -4 get default | awk '/interface: / {print $2}')
-ip6int=$(route -6 get default | awk '/interface: / {print $2}')
+ip4int=$(route -4 get default >/dev/null 2>&1 | awk '/interface: / {print $2}')
+ip6int=$(route -6 get default >/dev/null 2>&1 | awk '/interface: / {print $2}')
 ip4guess=$(ifconfig ${ip4int} | awk '/inet / && !/127.0/ {print $2}' | head -n 1)
 ip6guess=$(ifconfig ${ip6int} | awk '/inet6 / && !/(fe80| ::1)/ {print $2}' | head -n 1)
 


### PR DESCRIPTION
Hi,
If the host doesn't have IPV4 or IPV6 the variable `$ipv6int` or `$ipv4int` returns an error.
Even if a command like `mkjail create -h` works, it can also give this error in case IPV6 and/or IPV4 is missing.

Thank you.
