### PR TITLE
upgrade.sh: fix error message when a jail isn't running

### DIFF
--- a/src/share/mkjail/upgrade.sh
+++ b/src/share/mkjail/upgrade.sh
@@ -71,10 +71,9 @@ _validate()
     fi
 
     # Ensure jail is actually running
-    jls -j ${JAILNAME} 2> /dev/null 1> /dev/null
-    if [ ${?} -ne "0" ]; then
-        echo "Error: jail ${JAILNAME} not running."
-        exit 1
+    if ! jls -j ${JAILNAME} >/dev/null 2>&1 ; then
+      echo "Error: jail ${JAILNAME} not running."
+      exit 1
     fi
 
     # Capture mkjail:version zfs property for rollback


### PR DESCRIPTION
Hi,

`upgrade.sh` normally displays an error message when the jail we want to upgrade doesn't run, actually the script quits silently without showing anything.
If `myjail` is turned off and we execute the following command `mkjail upgrade -v 14.1-RELEASE -j myjail`, nothing will happen, the jail won't be upgraded but the user won't know why. 
That's because the option `set -e` forces the script to exit when the test `if [ ${?} -ne "0" ]; then` fails.
