### PR TITLE
Allow running without a vty

### DIFF
--- a/src/share/mkjail/update.sh
+++ b/src/share/mkjail/update.sh
@@ -25,7 +25,7 @@ _alljails()
         echo "Updating ${JAILNAME} jail..."
         echo ""
         export UNAME_r=$(_get_version)
-        PAGER=cat freebsd-update -b ${JAILROOT}/${JAILNAME} -f ${JAILROOT}/${JAILNAME}/etc/freebsd-update.conf -F fetch install
+        PAGER=cat freebsd-update --not-running-from-cron -b ${JAILROOT}/${JAILNAME} -f ${JAILROOT}/${JAILNAME}/etc/freebsd-update.conf -F fetch install
         _set_version
       fi
       echo ""
@@ -38,7 +38,7 @@ _onejail()
     echo "Updating ${JAILNAME} jail..."
     echo ""
     export UNAME_r=$(_get_version)
-    PAGER=cat freebsd-update -b ${JAILROOT}/${JAILNAME} -f ${JAILROOT}/${JAILNAME}/etc/freebsd-update.conf -F fetch install
+    PAGER=cat freebsd-update --not-running-from-cron -b ${JAILROOT}/${JAILNAME} -f ${JAILROOT}/${JAILNAME}/etc/freebsd-update.conf -F fetch install
     _set_version
     exit 0
 }

--- a/src/share/mkjail/upgrade.sh
+++ b/src/share/mkjail/upgrade.sh
@@ -54,7 +54,7 @@ _upgradejail()
     yes | jexec ${JAILNAME} make -C /usr/src delete-old-libs
 
     umount -f ${JAILROOT}/${JAILNAME}/usr/src
-    PAGER=cat freebsd-update -b ${JAILROOT}/${JAILNAME} -f ${JAILROOT}/${JAILNAME}/etc/freebsd-update.conf --currently-running ${TARGETVER} -F fetch install
+    PAGER=cat freebsd-update --not-running-from-cron -b ${JAILROOT}/${JAILNAME} -f ${JAILROOT}/${JAILNAME}/etc/freebsd-update.conf --currently-running ${TARGETVER} -F fetch install
     rm -rf ${JAILROOT}/${JAILNAME}/boot ${JAILROOT}/${JAILNAME}/src
     _set_version
 }


### PR DESCRIPTION
You have to provide --not-running-from-cron if running from another script/program when it's not being executed from cron.

This makes it possible to use mkjail with exec.prepare:

exec.prepare = "test -d $path || mkjail create -v 15.0-RELEASE -j $name";

If you use that in jail.conf, it will automatically create the jail for you the first time you try to start it.